### PR TITLE
Update yeelightblue.py

### DIFF
--- a/yeelightblue.py
+++ b/yeelightblue.py
@@ -71,3 +71,14 @@ class YeeLightBlue:
     def delayOnStatusQuery(self):
         '''TODO: Function is missing UUID/Handle'''
         self.con.sendline('char-write-cmd 0x00__ RT')
+
+    def white(self,temperature,brightness):
+        a_str = "CLTMP " + temperature + ',' + brightness + ','
+        for letter in range(len(a_str),18):
+            #print letter
+            a_str += ','
+            #print a_str
+        self.str2hex(a_str)
+	print a_str
+        print self.hexStr
+        self.con.sendline('char-write-cmd 0x0012 ' + self.hexStr)


### PR DESCRIPTION
Added function for controlling white colour temperature and brightness of YeeLight Blue II bulb.
"CLTMP 6500,100,,,," is **much much brighter** than "255,255,255,100,,,".
Usage x.white(temperature,brightness)
Modeled on original code, arguments are strings.
temperature '1700' to '6500'
brightness '0' to '100'